### PR TITLE
add whitelist network patch

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -62,3 +62,7 @@ $rcmail_config['rcguard_ipv6_prefix'] = 0;
 
 // Do not show recaptcha for this IPs
 $rcmail_config['rcguard_ignore_ips'] = array();
+
+// Do not show recaptcha of these networks
+$rcmail_config['recaptcha_whitelist'] = array();
+


### PR DESCRIPTION
A small change to enable an administrator to block showing the captcha to entire networks instead of single ip addresses. Already tested on roundcube 1.1.5 and 1.2.7.