### PR TITLE
Fix 'Unsupported operand types: string & bool' with IPv6 clients on PHP 8+

### DIFF
--- a/rcguard.php
+++ b/rcguard.php
@@ -395,8 +395,8 @@ class rcguard extends rcube_plugin
             // construct subnet mask
             $mask_string = str_repeat('1', $prefix) . str_repeat('0', 128 - $prefix);
             $mask_split = str_split($mask_string, 16);
-            foreach ($mask_split as $item) {
-                $item = base_convert($item, 2, 16);
+            for ($i = 0; $i < count($mask_split); $i++) {
+                $mask_split[$a] = base_convert($mask_split[$a], 2, 16);
             }
             $mask_hex = implode(':', $mask_split);
 


### PR DESCRIPTION
When a client connects to a roundcube instanced with rcguard active, the request aborts with a HTTP 500 error due to an exception.

```
PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string & bool in /var/www/htdocs/plugins/roundcube-rcguard-1.3.2/rcguard.php:404
Stack trace:
#0 /var/www/htdocs/plugins/roundcube-rcguard-1.3.2/rcguard.php(53): rcguard->get_client_ip()
#1 /var/www/htdocs/program/lib/Roundcube/rcube_plugin_api.php(105): rcguard->init()
#2 /var/www/htdocs/program/include/rcmail.php(153): rcube_plugin_api->init()
#3 /var/www/htdocs/program/include/rcmail.php(86): rcmail->startup()
#4 /var/www/htdocs/index.php(43): rcmail::get_instance()
#5 {main}
  thrown in /var/www/htdocs/plugins/roundcube-rcguard-1.3.2/rcguard.php on line 404
```

Code to reproduce (extracted from the plugins code):
```bash
cat >/tmp/test.php <<"EOF"
<?php
$prefix = 64;
$client_ip = "2001:db8:abcd:0012:1234::3";
$mask_string = str_repeat('1', $prefix) . str_repeat('0', 128 - $prefix);
$mask_split = str_split($mask_string, 16);
foreach ($mask_split as $item) {
  $item = base_convert($item, 2, 16);
}
$mask_hex = implode(':', $mask_split);

var_dump(array(
  inet_pton($client_ip),
  inet_pton($mask_hex),
  inet_pton($client_ip) & inet_pton($mask_hex)
));
EOF

php /tmp/test.php
```

Prior PHP 8 (e.g. with 7.4), the '&' returns an int and issues just a warning (`A non-numeric value encountered in /tmp/test.php on line 14`).