### PR TITLE
Add support for IPv6 CIDR match

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -57,7 +57,7 @@ $config['recaptcha_log_success'] = 'Verification succeeded for %u. [%r]';
 $config['recaptcha_log_failure'] = 'Error: Verification failed for %u. [%r]';
 $config['recaptcha_log_unknown'] = 'Error: Unknown log type.';
 
-// Block IPv6 clients based on prefix length
+// Mask IPv6 client IP based on prefix length
 // Use an integer between 16 and 128, 0 to disable
 $config['rcguard_ipv6_prefix'] = 0;
 

--- a/rcguard.php
+++ b/rcguard.php
@@ -55,10 +55,12 @@ class rcguard extends rcube_plugin
 
         if (in_array($client_ip, $ignore_ips)) {
             $whitelisted = true;
+            rcube::write_log('rcguard', 'Captcha verification skipped because of client IP ' . $client_ip . ' found in ignore list');
         } else {
             foreach ($this->rc->config->get('recaptcha_whitelist', []) as $network) {
                 if ($this->cidr_match($client_ip, $network)) {
                     $whitelisted = true;
+                    rcube::write_log('rcguard', 'Captcha verification skipped because of client IP ' . $client_ip . ' matches whitelist entry ' . $network);
                     break;
                 }
             }

--- a/rcguard.php
+++ b/rcguard.php
@@ -435,7 +435,7 @@ class rcguard extends rcube_plugin
 
         if (strpos($cidr, '/') === false) {
             if ($cidr_match_ipv6 == true) {
-                    $cidr .= '/64'; // default prefix length for global IPv6 addresses
+                    $cidr .= '/128';
             } else {
                     $cidr .= '/32';
             };

--- a/rcguard.php
+++ b/rcguard.php
@@ -433,15 +433,13 @@ class rcguard extends rcube_plugin
                 $cidr_match_ipv6 = true;
         };
 
-        if ($cidr_match_ipv6 == true) {
-            if (strpos($cidr, '/') === false) {
+        if (strpos($cidr, '/') === false) {
+            if ($cidr_match_ipv6 == true) {
                     $cidr .= '/64'; // default prefix length for global IPv6 addresses
-            }
-        } else {
-            if (strpos($cidr, '/') === false) {
+            } else {
                     $cidr .= '/32';
-            }
-        };
+            };
+        }
 
         list($subnet, $bits) = explode('/', $cidr);
 

--- a/rcguard.php
+++ b/rcguard.php
@@ -397,8 +397,8 @@ class rcguard extends rcube_plugin
             // construct subnet mask
             $mask_string = str_repeat('1', $prefix) . str_repeat('0', 128 - $prefix);
             $mask_split = str_split($mask_string, 16);
-            foreach ($mask_split as $item) {
-                $item = base_convert($item, 2, 16);
+            for ($i = 0; $i < count($mask_split); $i++) {
+                $mask_split[$i] = base_convert($mask_split[$i], 2, 16);
             }
             $mask_hex = implode(':', $mask_split);
 


### PR DESCRIPTION
So far, IPv6 entries in `$config['recaptcha_whitelist']` where not proper honored, this PR adds IPv6 support to the CIDR matching code using e.g. following config

```
$rcmail_config['recaptcha_whitelist'] = array('2001:db8::/32');
```
also add some log lines and fixes the somehow broken code mentioned in https://github.com/dsoares/roundcube-rcguard/pull/46.

BTW: reason for config option

```
// Block IPv6 client IP based on prefix length
// Use an integer between 16 and 128, 0 to disable
$config['rcguard_ipv6_prefix'] = 0;
```

is unclear, there was no code sniplet found which blocks something, with that PR it's at least proper masking (for whatever reason...)